### PR TITLE
[KAIZEN-0] Håndtere både identer og aktørIder

### DIFF
--- a/apps/arena-infotrygd-soknadsstatus-transform/build.gradle.kts
+++ b/apps/arena-infotrygd-soknadsstatus-transform/build.gradle.kts
@@ -32,6 +32,7 @@ dependencies {
     implementation(project(":common:dataformat"))
     implementation(project(":common:filter"))
     implementation(project(":common:kafka"))
+    implementation(project(":tjenestespesifikasjoner:pdl-api"))
     implementation("net.logstash.logback:logstash-logback-encoder:$logstash_version")
     implementation("ch.qos.logback:logback-classic:$logback_version")
     implementation("io.ktor:ktor-server-cio-jvm:2.3.1")

--- a/apps/arena-infotrygd-soknadsstatus-transform/src/main/kotlin/no/nav/modia/soknadsstatus/Main.kt
+++ b/apps/arena-infotrygd-soknadsstatus-transform/src/main/kotlin/no/nav/modia/soknadsstatus/Main.kt
@@ -3,6 +3,7 @@ package no.nav.modia.soknadsstatus
 import io.ktor.server.application.*
 import io.ktor.server.cio.*
 import kotlinx.serialization.json.Json
+import no.nav.api.generated.pdl.enums.IdentGruppe
 import no.nav.modia.soknadsstatus.behandling.Behandling
 import no.nav.modia.soknadsstatus.kafka.*
 import no.nav.personoversikt.common.ktor.utils.KtorServer
@@ -76,4 +77,8 @@ fun deserialize(key: String?, value: String): Behandling {
     }
 }
 
-fun transform(key: String?, behandling: Behandling) = Transformer.transform(behandling, InfotrygdAvslutningsstatusMapper)
+fun transform(key: String?, behandling: Behandling) = Transformer.transform(
+    behandling = behandling,
+    identGruppe = IdentGruppe.AKTORID,
+    statusMapper = InfotrygdAvslutningsstatusMapper
+)

--- a/apps/arena-infotrygd-soknadsstatus-transform/src/test/kotlin/no/nav/modia/soknadsstatus/ArenaInfotrygdSoknadsstatusTransformTest.kt
+++ b/apps/arena-infotrygd-soknadsstatus-transform/src/test/kotlin/no/nav/modia/soknadsstatus/ArenaInfotrygdSoknadsstatusTransformTest.kt
@@ -24,7 +24,7 @@ class ArenaInfotrygdSoknadsstatusTransformTest {
 
         val oppdatering = transform(null, behandling)
 
-        assertEquals(oppdatering.aktorIder.first(), "19099531196")
+        assertEquals("19099531196", oppdatering.identer?.first()?.ident)
         assertEquals(oppdatering.behandlingsId, "1500oVFWH")
     }
 
@@ -34,8 +34,8 @@ class ArenaInfotrygdSoknadsstatusTransformTest {
 
         val oppdatering = transform(null, behandling)
 
-        assertEquals(oppdatering.aktorIder.first(), "26127338824")
-        assertEquals(oppdatering.behandlingsId, "1500oVFWi")
+        assertEquals("26127338824", oppdatering.identer?.first()?.ident)
+        assertEquals("1500oVFWi", oppdatering.behandlingsId)
     }
 
     @Test
@@ -44,7 +44,7 @@ class ArenaInfotrygdSoknadsstatusTransformTest {
 
         val oppdatering = transform(null, behandling)
 
-        assertEquals(oppdatering.aktorIder.first(), "26127338824")
-        assertEquals(oppdatering.behandlingsId, "1500oVFWi")
+        assertEquals("26127338824", oppdatering.identer?.first()?.ident)
+        assertEquals("1500oVFWi", oppdatering.behandlingsId)
     }
 }

--- a/apps/modia-soknadsstatus-api/src/test/kotlin/no/nav/modia/soknadsstatus/SoknadsstatusServiceTest.kt
+++ b/apps/modia-soknadsstatus-api/src/test/kotlin/no/nav/modia/soknadsstatus/SoknadsstatusServiceTest.kt
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.TestInstance.Lifecycle
 import org.junit.jupiter.api.assertThrows
 
-val aktorIder = listOf("10108000398", "2222222222")
+val aktorIder = listOf("1010800039812", "222222222212")
 val oppdatering = SoknadsstatusDomain.SoknadsstatusInnkommendeOppdatering(
     aktorIder = aktorIder,
     behandlingsId = "12345",
@@ -37,7 +37,7 @@ class SoknadsstatusServiceTest {
     }
 
     @Test
-    fun `skal lagre alle aktørider i databasen`() {
+    fun `skal lagre alle identer i databasen`() {
         coEvery { pdlOppslagServiceImpl.hentFnrMedSystemToken(any()) }.returnsMany(aktorIder.first(), aktorIder[1])
         coEvery { pdlOppslagServiceImpl.hentAktiveIdenter(any(), any()) }.returnsMany(listOf(aktorIder.first()))
 

--- a/apps/soknadsstatus-hendelse-transform/build.gradle.kts
+++ b/apps/soknadsstatus-hendelse-transform/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
     implementation(project(":common:filter"))
     implementation(project(":common:kafka"))
     implementation(project(":common:utils"))
+    implementation(project(":tjenestespesifikasjoner:pdl-api"))
     implementation("net.logstash.logback:logstash-logback-encoder:$logstash_version")
     implementation("ch.qos.logback:logback-classic:$logback_version")
     testImplementation("org.junit.jupiter:junit-jupiter:$junit_version")

--- a/apps/soknadsstatus-hendelse-transform/src/main/kotlin/no/nav/modia/soknadsstatus/Main.kt
+++ b/apps/soknadsstatus-hendelse-transform/src/main/kotlin/no/nav/modia/soknadsstatus/Main.kt
@@ -3,6 +3,7 @@ package no.nav.modia.soknadsstatus
 import io.ktor.server.application.*
 import io.ktor.server.cio.*
 import kotlinx.serialization.json.Json
+import no.nav.api.generated.pdl.enums.IdentGruppe
 import no.nav.modia.soknadsstatus.behandling.Behandling
 import no.nav.modia.soknadsstatus.kafka.*
 import no.nav.personoversikt.common.ktor.utils.KtorServer
@@ -76,4 +77,8 @@ fun serialize(key: String?, value: SoknadsstatusDomain.SoknadsstatusInnkommendeO
     value,
 )
 
-fun transform(key: String?, behandling: Behandling) = Transformer.transform(behandling, HendelseAvslutningsstatusMapper)
+fun transform(key: String?, behandling: Behandling) = Transformer.transform(
+    behandling = behandling,
+    identGruppe = IdentGruppe.AKTORID,
+    statusMapper = HendelseAvslutningsstatusMapper
+)

--- a/common/dataformat/build.gradle.kts
+++ b/common/dataformat/build.gradle.kts
@@ -19,6 +19,7 @@ dependencies {
     implementation(kotlin("stdlib"))
     implementation(project(":common:utils"))
     implementation(project(":common:ktor"))
+    implementation(project(":tjenestespesifikasjoner:pdl-api"))
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-core:$kotlinx_serialization_version")
     implementation("org.jetbrains.kotlinx:kotlinx-datetime:$kotlinx_datetime_version")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinx_serialization_version")

--- a/common/dataformat/src/main/kotlin/no/nav/modia/soknadsstatus/SoknadsstatusDomain.kt
+++ b/common/dataformat/src/main/kotlin/no/nav/modia/soknadsstatus/SoknadsstatusDomain.kt
@@ -2,6 +2,7 @@ package no.nav.modia.soknadsstatus
 
 import kotlinx.datetime.Instant
 import kotlinx.serialization.Serializable
+import no.nav.api.generated.pdl.enums.IdentGruppe
 import org.apache.kafka.common.serialization.Deserializer
 import org.apache.kafka.common.serialization.Serde
 import org.apache.kafka.common.serialization.Serializer
@@ -29,18 +30,26 @@ object SoknadsstatusDomain {
 
     @Serializable
     data class SoknadsstatusInnkommendeOppdatering(
-        val aktorIder: List<String>,
+        val aktorIder: List<String>? = null,
+        val identer: List<IdentType>? = null,
         val behandlingsId: String,
         val systemRef: String,
         val tema: String,
         val status: Status,
         val tidspunkt: Instant,
-    )
-
-    class SoknadsstatusInkommendeOppdateringSerde : Serde<SoknadsstatusInnkommendeOppdatering> {
-        override fun serializer() = SoknadsstatusInnkommendeOppdateringSerializer()
-        override fun deserializer() = SoknadsstatusInnkommendeOppdateringDeserializer()
+    ) {
+        init {
+            if (aktorIder == null && identer == null) {
+                throw IllegalArgumentException("Enten aktorIder eller identer må være satt")
+            }
+        }
     }
+
+    @Serializable
+    data class IdentType(
+        val ident: String,
+        val type: IdentGruppe
+    )
 
     @Serializable
     data class Soknadsstatuser(
@@ -54,30 +63,4 @@ object SoknadsstatusDomain {
         var ferdigBehandlet: Int = 0,
         var avbrutt: Int = 0,
     )
-}
-
-class SoknadsstatusInnkommendeOppdateringSerializer :
-    Serializer<SoknadsstatusDomain.SoknadsstatusInnkommendeOppdatering> {
-    override fun serialize(topic: String?, data: SoknadsstatusDomain.SoknadsstatusInnkommendeOppdatering?): ByteArray {
-        if (data == null) {
-            return ByteArray(0)
-        }
-        val encodedSoknadsstatus =
-            Encoding.encode(SoknadsstatusDomain.SoknadsstatusInnkommendeOppdatering.serializer(), data)
-        return encodedSoknadsstatus.encodeToByteArray()
-    }
-}
-
-class SoknadsstatusInnkommendeOppdateringDeserializer :
-    Deserializer<SoknadsstatusDomain.SoknadsstatusInnkommendeOppdatering> {
-    override fun deserialize(
-        topic: String?,
-        data: ByteArray?,
-    ): SoknadsstatusDomain.SoknadsstatusInnkommendeOppdatering? {
-        if (data == null) {
-            return null
-        }
-        val encodedString = data.toString(Charsets.UTF_8)
-        return Encoding.decode(SoknadsstatusDomain.SoknadsstatusInnkommendeOppdatering.serializer(), encodedString)
-    }
 }

--- a/common/dataformat/src/main/kotlin/no/nav/modia/soknadsstatus/Transformer.kt
+++ b/common/dataformat/src/main/kotlin/no/nav/modia/soknadsstatus/Transformer.kt
@@ -2,6 +2,7 @@ package no.nav.modia.soknadsstatus
 
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toInstant
+import no.nav.api.generated.pdl.enums.IdentGruppe
 import no.nav.modia.soknadsstatus.behandling.Behandling
 import no.nav.modia.soknadsstatus.behandling.BehandlingAvsluttet
 import no.nav.modia.soknadsstatus.behandling.BehandlingOpprettet
@@ -19,14 +20,20 @@ object Transformer {
     @JvmStatic
     fun transform(
         behandling: Behandling,
-        mapper: AvslutningsStatusMapper
+        identGruppe: IdentGruppe,
+        statusMapper: AvslutningsStatusMapper
     ): SoknadsstatusDomain.SoknadsstatusInnkommendeOppdatering {
         return SoknadsstatusDomain.SoknadsstatusInnkommendeOppdatering(
-            aktorIder = behandling.aktoerREF.map { it.aktoerId },
+            identer = behandling.aktoerREF.map {
+                SoknadsstatusDomain.IdentType(
+                    ident = it.aktoerId,
+                    identGruppe,
+                )
+            },
             tema = behandling.sakstema.value,
             behandlingsId = behandling.behandlingsID,
             systemRef = behandling.hendelsesprodusentREF.value,
-            status = behandlingsStatus(behandling, mapper),
+            status = behandlingsStatus(behandling, statusMapper),
             tidspunkt = behandling.hendelsesTidspunkt.toInstant(TimeZone.currentSystemDefault()),
         )
     }


### PR DESCRIPTION
Infotrygd sender brukeridenter og kafka meldingene kommer inn med aktørId