### PR TITLE
[KAIZEN-0] Legg til aktor_id på eiere

### DIFF
--- a/apps/modia-soknadsstatus-api/src/main/kotlin/no/nav/modia/soknadsstatus/repository/BehandlingEierRepository.kt
+++ b/apps/modia-soknadsstatus-api/src/main/kotlin/no/nav/modia/soknadsstatus/repository/BehandlingEierRepository.kt
@@ -16,6 +16,7 @@ interface BehandlingEiereRepository : TransactionRepository {
 data class BehandlingEierDAO(
     val id: String? = null,
     val ident: String? = null,
+    val aktorId: String? = null,
     val behandlingId: String? = null,
 )
 
@@ -28,6 +29,7 @@ class BehandlingEierRepositoryImpl(
 
         val id = "id"
         const val ident = "ident"
+        const val aktorId = "aktor_id"
         const val behandlingId = "behandling_id"
     }
 
@@ -38,12 +40,13 @@ class BehandlingEierRepositoryImpl(
         connection
             .executeWithResult(
                 """
-                INSERT INTO $Tabell(${Tabell.behandlingId}, ${Tabell.ident}) VALUES(?::uuid, ?)
+                INSERT INTO $Tabell(${Tabell.behandlingId}, ${Tabell.ident}, ${Tabell.aktorId}) VALUES(?::uuid, ?, ?)
                  ON CONFLICT DO NOTHING
                  RETURNING *;
                 """.trimIndent(),
                 behandlingEier.behandlingId,
                 behandlingEier.ident,
+                behandlingEier.aktorId,
             ) {
                 BehandlingEierDAO(
                     id = it.getString(Tabell.id),

--- a/apps/modia-soknadsstatus-api/src/main/kotlin/no/nav/modia/soknadsstatus/repository/HendelseEierRepository.kt
+++ b/apps/modia-soknadsstatus-api/src/main/kotlin/no/nav/modia/soknadsstatus/repository/HendelseEierRepository.kt
@@ -16,6 +16,7 @@ interface HendelseEierRepository : TransactionRepository {
 data class HendelseEierDAO(
     val id: String? = null,
     val ident: String? = null,
+    val aktorId: String? = null,
     val hendelseId: String? = null,
 )
 
@@ -28,6 +29,7 @@ class HendelseEierRepositoryImpl(
 
         val id = "id"
         val ident = "ident"
+        val aktorId = "aktor_id"
         val hendelseId = "hendelse_id"
     }
 
@@ -38,12 +40,13 @@ class HendelseEierRepositoryImpl(
         connection
             .executeWithResult(
                 """
-                INSERT INTO $Tabell(${Tabell.hendelseId}, ${Tabell.ident}) VALUES(?::uuid, ?)
+                INSERT INTO $Tabell(${Tabell.hendelseId}, ${Tabell.ident}, ${Tabell.aktorId}) VALUES(?::uuid, ?, ?)
                  ON CONFLICT DO NOTHING
                  RETURNING *;
                 """.trimIndent(),
                 hendelseEier.hendelseId,
                 hendelseEier.ident,
+                hendelseEier.aktorId,
             ) {
                 HendelseEierDAO(
                     id = it.getString(Tabell.id),

--- a/apps/modia-soknadsstatus-api/src/main/resources/db/migration/V1_7__aktor_id_hendelse_og_behandling_eiere.sql
+++ b/apps/modia-soknadsstatus-api/src/main/resources/db/migration/V1_7__aktor_id_hendelse_og_behandling_eiere.sql
@@ -1,0 +1,2 @@
+ALTER TABLE behandling_eiere ADD COLUMN "aktor_id" VARCHAR(128);
+ALTER TABLE hendelse_eiere ADD COLUMN "aktor_id" VARCHAR(128);


### PR DESCRIPTION
Legg til aktor_id og bruk denne på hendelse_eiere og behandling_eiere
tabellene istedetfor å endre til ident hver gang. Dette for å la oss
gjøre aktorId -> ident mer effektivt i en batch jobb senere.