### PR TITLE
[KAIZEN-0] Join også på aktor_id for duplikater

### DIFF
--- a/apps/modia-soknadsstatus-api/src/main/kotlin/no/nav/modia/soknadsstatus/AktorMigreringJob.kt
+++ b/apps/modia-soknadsstatus-api/src/main/kotlin/no/nav/modia/soknadsstatus/AktorMigreringJob.kt
@@ -37,7 +37,6 @@ class AktorMigreringJob(
                     logger.info("Konverterer aktor_id til ident for hendelse_eiere (${aktorFnrMapping.size} elementer)")
                     val hendelseEierRes = services.hendelseEierService.convertAktorToIdent(aktorFnrMapping)
                     logger.info("Slettet ${hendelseEierRes.deleteCount} rader. Oppdaterte ${hendelseEierRes.updateCount} rader")
-                    logger.info("Konverterer aktor_id til ident for hendelse_eiere (${aktorFnrMapping.size} elementer)")
 
                     logger.info("Migrerte aktor ID til FNR for ${aktorFnrMapping.size} elemeter")
                 } catch (e: Exception) {

--- a/apps/modia-soknadsstatus-api/src/main/kotlin/no/nav/modia/soknadsstatus/repository/BehandlingEierRepository.kt
+++ b/apps/modia-soknadsstatus-api/src/main/kotlin/no/nav/modia/soknadsstatus/repository/BehandlingEierRepository.kt
@@ -113,7 +113,7 @@ class BehandlingEierRepositoryImpl(
                     INNER JOIN (
                         SELECT (value->>0) AS aktor_id, (value->>1) AS ident from json_array_elements(?::json)
                     ) AS Q
-                    ON Q.ident = b.${Tabell.ident}
+                    ON Q.ident = b.${Tabell.ident} OR Q.aktor_id = b.${Tabell.aktorId}
                     WHERE
                         b.${Tabell.behandlingId} = a.${Tabell.behandlingId}
                         AND Q.aktor_id = a.${Tabell.aktorId}

--- a/apps/modia-soknadsstatus-api/src/main/kotlin/no/nav/modia/soknadsstatus/repository/HendelseEierRepository.kt
+++ b/apps/modia-soknadsstatus-api/src/main/kotlin/no/nav/modia/soknadsstatus/repository/HendelseEierRepository.kt
@@ -94,7 +94,7 @@ class HendelseEierRepositoryImpl(
                     INNER JOIN (
                         SELECT (value->>0) AS aktor_id, (value->>1) AS ident from json_array_elements(?::json)
                     ) AS Q
-                    ON Q.ident = b.${Tabell.ident}
+                    ON Q.ident = b.${Tabell.ident} OR Q.aktor_id = b.${Tabell.aktorId}
                     WHERE
                         b.${Tabell.hendelseId} = a.${Tabell.hendelseId}
                         AND Q.aktor_id = a.${Tabell.aktorId}


### PR DESCRIPTION
Vi kan ha rader som er duplikate på (behandling_id, aktor_id) og der det
ikke finnes noen rader med samme behandling_id og ident. Da vil ikke
quierien som var plukke opp de andre duplikatene.
