### PR TITLE
Oppgrader database for migrasjon

### DIFF
--- a/apps/modia-soknadsstatus-api/.nais/prod.yaml
+++ b/apps/modia-soknadsstatus-api/.nais/prod.yaml
@@ -50,7 +50,7 @@ spec:
       - type: POSTGRES_14
         diskAutoresize: true
         highAvailability: true
-        tier: db-custom-8-20480
+        tier: db-custom-32-40960
         databases:
           - name: modia-soknadsstatus-api-db
   leaderElection: true


### PR DESCRIPTION
Produksjons databasen feiler på temp_file_limit når vi skal hente ident under migrasjon fra sob.
