### PR TITLE
Håndter NPID og manglende ident i aktor migrering

### DIFF
--- a/apps/modia-soknadsstatus-api/src/main/kotlin/no/nav/modia/soknadsstatus/AktorMigreringJob.kt
+++ b/apps/modia-soknadsstatus-api/src/main/kotlin/no/nav/modia/soknadsstatus/AktorMigreringJob.kt
@@ -22,7 +22,10 @@ class AktorMigreringJob(
                 try {
                     logger.info("Henter nye aktor IDer for migrering til Fnr")
                     val aktorIder = services.behandlingEierService.getAktorIdsToConvert(1000)
-                    if (aktorIder.isEmpty()) continue
+                    if (aktorIder.isEmpty()) {
+                        logger.info("Ingen aktor IDer funnet. Avlustter jobb...")
+                        return
+                    }
 
                     val aktorFnrMapping = services.pdlMigrering.hentFnrMedSystemTokenBolk(aktorIder)
                     if (aktorFnrMapping.isEmpty()) {

--- a/apps/modia-soknadsstatus-api/src/main/kotlin/no/nav/modia/soknadsstatus/pdl/PdlOppslagServiceImpl.kt
+++ b/apps/modia-soknadsstatus-api/src/main/kotlin/no/nav/modia/soknadsstatus/pdl/PdlOppslagServiceImpl.kt
@@ -45,7 +45,7 @@ class PdlOppslagServiceImpl(
         try {
             return pdlClient.hentAktivIdentMedSystemTokenBolk(
                 aktorIds,
-                listOf(IdentGruppe.FOLKEREGISTERIDENT, IdentGruppe.AKTORID),
+                listOf(IdentGruppe.FOLKEREGISTERIDENT, IdentGruppe.AKTORID, IdentGruppe.NPID),
             )
         } catch (e: IllegalArgumentException) {
             TjenestekallLogg.warn(


### PR DESCRIPTION
Det er noen tilfeller der personer vi har lagret på aktorId ikke har en folkeregisterident. Vi
prøver dermed å hente ut NPID om den eksisterer og i værste fall håndtere at identen ikke finnes og
ignorere den og logge error slik at jobben kan fortsette.
