### PR TITLE
Fjerne kode som sletter duplikate eier (aktor, id)

### DIFF
--- a/apps/modia-soknadsstatus-api/src/main/kotlin/no/nav/modia/soknadsstatus/service/BehandlingEierService.kt
+++ b/apps/modia-soknadsstatus-api/src/main/kotlin/no/nav/modia/soknadsstatus/service/BehandlingEierService.kt
@@ -31,11 +31,10 @@ class BehandlingEierServiceImpl(
 
     override suspend fun convertAktorToIdent(aktorFnrMapping: List<Pair<String, String>>) =
         behandlingEiereRepository.useTransactionConnection {
-            val deleteCount = behandlingEiereRepository.deleteDuplicateRowsByIdentAktorMapping(it, aktorFnrMapping)
             val updateCount = behandlingEiereRepository.updateAktorToFnr(it, aktorFnrMapping)
 
             DeleteUpdateResult(
-                deleteCount,
+                deleteCount = 0,
                 updateCount,
             )
         }

--- a/apps/modia-soknadsstatus-api/src/main/kotlin/no/nav/modia/soknadsstatus/service/HendelseEierService.kt
+++ b/apps/modia-soknadsstatus-api/src/main/kotlin/no/nav/modia/soknadsstatus/service/HendelseEierService.kt
@@ -24,11 +24,10 @@ class HendelseEierServiceImpl(
 
     override suspend fun convertAktorToIdent(aktorFnrMapping: List<Pair<String, String>>) =
         hendelseEierRepository.useTransactionConnection {
-            val deleteCount = hendelseEierRepository.deleteDuplicateRowsByIdentAktorMapping(it, aktorFnrMapping)
             val updateCount = hendelseEierRepository.updateAktorToFnr(it, aktorFnrMapping)
 
             DeleteUpdateResult(
-                deleteCount,
+                deleteCount = 0,
                 updateCount,
             )
         }


### PR DESCRIPTION
I både hendelse_eier og behandling_eier. Vi sletter duplikater
separat.
